### PR TITLE
Coloring of Quiver Arrows

### DIFF
--- a/src/polplot/polplot.py
+++ b/src/polplot/polplot.py
@@ -449,7 +449,7 @@ class Polarplot(object):
         return tuple(returns)
 
 
-    def quiver(self, lat, lt, poleward, eastward, rotation=0, qkeyproperties=None, **kwargs):
+    def quiver(self, lat, lt, poleward, eastward, mag, rotation=0, qkeyproperties=None, **kwargs):
         """
         Wrapper for Matplotlib's quiver function for latitude/local time coordinates.
 
@@ -466,6 +466,8 @@ class Polarplot(object):
             Poleward component of each vector.
         eastward : array_like
             Eastward component of each vector.
+        mag : array_like
+            The magnitude of the vectors, used for coloring.
         rotation : float, optional
             Rotation angle for the vectors, in radians. Default is 0.
         qkeyproperties : dict or None, optional
@@ -494,7 +496,7 @@ class Polarplot(object):
         x, y = self._latlt2xy(lat, lt)
         dx, dy = R.dot(self._northEastToCartesian(poleward, eastward, lt))
 
-        q = self.ax.quiver(x, y, dx, dy, **kwargs)
+        q = self.ax.quiver(x, y, dx, dy, mag, **kwargs)
 
         if qkeyproperties is not None:
             qkeykwargs = {'X': .8, 'Y': .9, 'labelpos': 'E'}

--- a/src/polplot/polplot.py
+++ b/src/polplot/polplot.py
@@ -449,7 +449,7 @@ class Polarplot(object):
         return tuple(returns)
 
 
-    def quiver(self, lat, lt, poleward, eastward, mag, rotation=0, qkeyproperties=None, **kwargs):
+    def quiver(self, lat, lt, poleward, eastward, mag=None, rotation=0, qkeyproperties=None, **kwargs):
         """
         Wrapper for Matplotlib's quiver function for latitude/local time coordinates.
 
@@ -496,8 +496,11 @@ class Polarplot(object):
         x, y = self._latlt2xy(lat, lt)
         dx, dy = R.dot(self._northEastToCartesian(poleward, eastward, lt))
 
-        q = self.ax.quiver(x, y, dx, dy, mag, **kwargs)
-
+        if mag is not None:
+            q = self.ax.quiver(x, y, dx, dy, mag, **kwargs)
+        else:
+            q = self.ax.quiver(x, y, dx, dy, **kwargs)
+            
         if qkeyproperties is not None:
             qkeykwargs = {'X': .8, 'Y': .9, 'labelpos': 'E'}
             qkeykwargs.update(qkeyproperties)


### PR DESCRIPTION
Updated polplot quiver to include the optional mag input, defines the vector magnitudes and necessary when passing to matpolotlib quiver for proper arrow coloring. Also placed mag in the 5th argument slot where rotation previously was. This was to mimic the matplotlib quiver argument order as shown here [https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.quiver.html](url)